### PR TITLE
Depend on `jupyterlite-core`

### DIFF
--- a/build-environment.yml
+++ b/build-environment.yml
@@ -6,5 +6,7 @@ dependencies:
   - pip
   - jupyter_server
   - pip:
-    - jupyterlite===0.1.0b18
+    # TODO: add pin
+    # - jupyterlite-core==0.1.0b19
+    - jupyterlite-core
     - jupyterlite-xeus-python==0.6.2

--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -2,8 +2,7 @@
     "jupyter-lite-schema-version": 0,
     "jupyter-config-data": {
       "disabledExtensions": [
-        "@jupyterlite/javascript-kernel-extension",
-        "@jupyterlite/pyolite-kernel-extension"
+        "@jupyterlite/javascript-kernel-extension"
       ]
     }
   }


### PR DESCRIPTION
Follow-up to https://github.com/jupyterlite/jupyterlite/pull/994.

Pending https://github.com/jupyterlite/jupyterlite/pull/1001 and a `jupyterlite-core==0.1.0b19` release.

This will avoid having to explicitly disable the Pyodide kernel in `jupyter-lite.json` config file.