### PR TITLE
Update to `jupyterlite-core==0.1.0b20`

### DIFF
--- a/build-environment.yml
+++ b/build-environment.yml
@@ -6,5 +6,5 @@ dependencies:
   - pip
   - jupyter_server
   - pip:
-    - jupyterlite-core==0.1.0b19
+    - jupyterlite-core==0.1.0b20
     - jupyterlite-xeus-python==0.7.0

--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -1,8 +1,0 @@
-{
-    "jupyter-lite-schema-version": 0,
-    "jupyter-config-data": {
-      "disabledExtensions": [
-        "@jupyterlite/javascript-kernel-extension"
-      ]
-    }
-  }


### PR DESCRIPTION
## References

Update to the latest `jupyterlite-core`: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b20

Which does not include the JavaScript kernel by default anymore: https://github.com/jupyterlite/jupyterlite/pull/1013

## Code changes

- [x] Update to `jupyterlite-core==0.1.0b20`
- [x] Remove `jupyter-lite.json` as it is not needed anymore

## User-facing changes

None

## Backwards-incompatible changes

None
