### PR TITLE
Install `jupyterlite-xeus` from conda-forge

### DIFF
--- a/build-environment.yml
+++ b/build-environment.yml
@@ -6,5 +6,4 @@ dependencies:
   - pip
   - jupyter_server
   - jupyterlite-core >=0.2.0,<0.3.0
-  - pip:
-    - jupyterlite-xeus>=0.1.2,<0.2
+  - jupyterlite-xeus>=0.1.2,<0.2


### PR DESCRIPTION
`jupyterlite-xeus` should now be available on conda-forge: https://github.com/conda-forge/jupyterlite-xeus-feedstock